### PR TITLE
Specify the packaging branch in the Vcs-Git URL

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,7 @@ Build-Conflicts: libavahi-compat-libdnssd-dev,
                  libwww-ssl-dev
 Standards-Version: 4.1.3
 Vcs-Browser: https://github.com/rlaager/ntpsec-pkg
-Vcs-Git: https://github.com/rlaager/ntpsec-pkg.git
+Vcs-Git: https://github.com/rlaager/ntpsec-pkg.git#sid
 Homepage: https://www.ntpsec.org
 
 Package: ntpsec


### PR DESCRIPTION
@rlaager I believe this change will make Debian's [vcswatch for ntpsec](https://qa.debian.org/cgi-bin/vcswatch?package=ntpsec) happier.  It scans several branches, but `sid` isn't one of them.